### PR TITLE
Ansible 2.5 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/CSCfi/ansible-role-ip-forwarder.svg?branch=master)](https://travis-ci.org/CSCfi/ansible-role-ip-forwarder)
+
 # ansible-role-ip-forwarder
 An Ansible role for configuring IP forwarding on a machine using sysctl
 parameters and either direct iptables or firewalld.

--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -2,7 +2,8 @@
 - name: Check for masquerading
   shell: firewall-cmd --zone {{ firewalld_masq_zone }} --query-masquerade
   register: masquerade
-  always_run: yes
+  check_mode: no
+  changed_when: False
   failed_when: masquerade.rc >= 2
 
 - name: Add masquerading to zone

--- a/tasks/iptables.yml
+++ b/tasks/iptables.yml
@@ -1,7 +1,8 @@
 ---
 - name: get iptables rules
   shell: iptables -L; iptables -t nat -L
-  always_run: yes
+  check_mode: no
+  changed_when: False
   register: iptablesrules
 
 - name: allow forwarding traffic in iptables

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,11 +5,12 @@
 - name: get firewalld state
   shell: firewall-cmd --state
   ignore_errors: true
-  always_run: yes
+  check_mode: no
   register: firewalld_state
+  changed_when: False
 
-- include: iptables.yml
+- import_tasks: iptables.yml
   when: firewalld_state.rc != 0
 
-- include: firewalld.yml
+- import_tasks: firewalld.yml
   when: firewalld_state.rc == 0

--- a/tests/devel-centos7/Dockerfile
+++ b/tests/devel-centos7/Dockerfile
@@ -13,9 +13,9 @@ RUN yum clean all && \
     yum -y install acl sudo && \
     sed -i -e 's/^Defaults.*requiretty/Defaults    !requiretty/' -e 's/^%wheel.*ALL$/%wheel    ALL=(ALL)    NOPASSWD: ALL/' /etc/sudoers && \
     yum -y install PyYAML python-jinja2 python-httplib2 python-keyczar python-paramiko python-setuptools git python-pip && \
-    pip install --upgrade pip && \
+    pip install --upgrade --force-reinstall pip==9.0.3 && \
     pip install requests[security] && \
-    pip install pyrax pysphere boto boto3 passlib dnspython && \
+    pip install passlib dnspython && \
     sh -c 'yum -y remove libffi-devel || yum -y --setopt=tsflags=noscripts remove libffi-devel' && \
     yum -y remove $(rpm -qa "*-devel") && \
     yum -y groupremove "Development tools" && \

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -115,13 +115,13 @@ function test_playbook(){
     ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} ||(echo "first ansible run failed" && exit 2 )
 
 
-#    echo "TEST: idempotence test! Same as previous but now grep for changed=0.*failed=0"
-#    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} || grep -q 'changed=0.*failed=0' && (echo 'Idempotence test: pass' ) || (echo 'Idempotence test: fail' && exit 1)
+    echo "TEST: idempotence test! Same as previous but now grep for changed=0.*failed=0"
+    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} || grep -q 'changed=0.*failed=0' && (echo 'Idempotence test: pass' ) || (echo 'Idempotence test: fail' && exit 1)
 }
 function extra_tests(){
 
-    echo "TEST: ls /etc/puppet/*"
-    ls /etc/puppet/
+    echo "TEST: iptables-save"
+    iptables-save
 
 }
 
@@ -137,7 +137,7 @@ function main(){
     test_playbook_syntax
     test_playbook
     test_playbook_check
-#    extra_tests
+    extra_tests
 
 }
 


### PR DESCRIPTION
 - use check_mode: no instead of always_run
 - set changed_when: False on tasks that shouldn't change anything
 - use import_tasks instead of include:
 - testing:
   - idempotency test
   - fix to use pip 9.0.3 when installing ansible
   - print iptable-save at the end so one can visually confirm that this role did in fact change the firewall rules